### PR TITLE
Add clearAll Gate, Config, Layer overrides methods

### DIFF
--- a/src/Evaluator.ts
+++ b/src/Evaluator.ts
@@ -107,6 +107,18 @@ export default class Evaluator {
     this.layerOverrides[layerName] = overrides;
   }
 
+  public clearAllGateOverrides(): void {
+    this.gateOverrides = {};
+  }
+
+  public clearAllConfigOverrides(): void {
+    this.configOverrides = {};
+  }
+
+  public clearAllLayerOverrides(): void {
+    this.layerOverrides = {};
+  }
+
   public checkGate(user: StatsigUser, gateName: string): ConfigEvaluation {
     const override = this.lookupGateOverride(user, gateName);
     if (override) {

--- a/src/StatsigServer.ts
+++ b/src/StatsigServer.ts
@@ -574,6 +574,18 @@ export default class StatsigServer {
     );
   }
 
+  public clearAllGateOverrides(): void {
+    this._evaluator.clearAllGateOverrides();
+  }
+
+  public clearAllConfigOverrides(): void {
+    this._evaluator.clearAllConfigOverrides();
+  }
+
+  public clearAllLayerOverrides(): void {
+    this._evaluator.clearAllLayerOverrides();
+  }
+
   public getFeatureGateList(): string[] {
     return this._evaluator.getFeatureGateList();
   }


### PR DESCRIPTION
Introduces 3 new methods to the top level `StatsigServer` class, each of which calls into the `Evaluator` to set its respective backing object to an empty object:
- `clearAllGateOverrides`
- `clearAllConfigOverrides`
- `clearAllLayerOverrides`

Please let me know if different naming would help or if there is associated documentation that should be updated.


Resolves statsig-io/node-js-server-sdk#41

